### PR TITLE
Fix fetchRankings for SSR

### DIFF
--- a/src/components/rankingSet.tsx
+++ b/src/components/rankingSet.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 export async function fetchRankings(): Promise<{ userid: string; displayName: string; number: string }[]> {
     try {
-        const response = await fetch(`${window.location.origin}/api/rankings`, {
+        const response = await fetch('/api/rankings', {
             method: 'GET',
             headers: {
                 'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- fix `fetchRankings` to avoid using `window` during SSR

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844ec2d9f10832e899554b439657d96